### PR TITLE
fix: Dockerfile to be in right stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ COPY . .
 RUN yarn install
 RUN yarn build
 
-EXPOSE 80
+EXPOSE 3000
 
 CMD ["node", "dist/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node
+FROM node:slim
 
 WORKDIR /usr/src/app
 COPY package*.json ./
-COPY nodemon.json ./
-COPY tsconfig.json ./
+COPY . .
+RUN yarn install
+RUN yarn build
 
 EXPOSE 80
 
-CMD yarn install \
-    && yarn start
+CMD ["node", "dist/server.js"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       dockerfile: Dockerfile
     container_name: curhatan
     ports:
-     - "80:80"
+     - "80:3000"
     environment:
      - JWT_KEY=developmentpurpose
      - SERVER_PORT=3000


### PR DESCRIPTION
# Issue

I encountered an error while building the Docker image of the app using the current `Dockerfile`. Because it didn't actually build the actual javascript files and the wrong `CMD` value as well.
![image](https://user-images.githubusercontent.com/42166417/194017013-29e9f5f8-9576-4515-963f-7247fd2d36b4.png)


# What this PR does

* Fix the `Dockerfile` to have the correct build stages to run the app.
* Adjust the correct exposed port on `compose`

# Screenshot
![image](https://user-images.githubusercontent.com/42166417/194017433-697d3878-f7fe-4951-8d7c-d09e7c782a32.png)

